### PR TITLE
BUGFIX: declare flow 7 compatibility

### DIFF
--- a/Classes/Cart/Cart.php
+++ b/Classes/Cart/Cart.php
@@ -9,7 +9,7 @@ namespace PunktDe\Sylius\Cart\Cart;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
+use Psr\Log\LoggerInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use PunktDe\Sylius\Api\Dto\Cart as SyliusCart;
 use PunktDe\Sylius\Api\Dto\CartItem;
@@ -57,7 +57,7 @@ class Cart
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 

--- a/Classes/Cart/CartManager.php
+++ b/Classes/Cart/CartManager.php
@@ -9,7 +9,7 @@ namespace PunktDe\Sylius\Cart\Cart;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
+use Psr\Log\LoggerInterface;
 use Neos\Flow\ObjectManagement\Exception\UnknownObjectException;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -65,7 +65,7 @@ class CartManager
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 


### PR DESCRIPTION
## Description

With the release of Flow 7 the `Neos\Flow\Log\PsrSystemLoggerInterface` class was removed. This PR takes care of changing the `Neos\Flow\Log\PsrSystemLoggerInterface` too the recommended: `Psr\Log\LoggerInterface` class.

Source:
https://flowframework.readthedocs.io/en/7.0/TheDefinitiveGuide/PartV/ReleaseNotes/700.html#removed-php-classes